### PR TITLE
set `ExportEntireVideo` from 0 -> 2. 2 stops video from being exported

### DIFF
--- a/archive-template.xml
+++ b/archive-template.xml
@@ -30,7 +30,7 @@
             <Value name="FileType">"PersystLayout (*.lay)|*.lay|"</Value>
             <Value name="ApplyAR">0</Value>
             <Value name="Deindentify">1</Value>
-            <Value name="ExportEntireVideo">0</Value>
+            <Value name="ExportEntireVideo">2</Value>
             <Value name="ApplyAROnlyIfAvailable">0</Value>
         </Key>
         <Key name="Filters">0

--- a/main.py
+++ b/main.py
@@ -276,9 +276,9 @@ def main():
                             # PSCLI.exe /SourceFile="ENTERED PATH" /Archive / Options ="TEMP XML FILE" 
 
                             result = subprocess.run(pscli_command, capture_output=True, text=True)
-                            log_and_print(result.returncode)
-                            log_and_print(result.stderr)
-                            log_and_print(result.stdout)
+                            print(result.returncode)
+                            print(result.stderr)
+                            print(result.stdout)
                             if result.returncode == 0:
                                 write_to_csv(private_csv_payload,os.path.join(private_files_path, "full-report-private.csv") )
                                 write_to_csv(private_csv_payload,os.path.join(private_files_path, f"{encoded_file_name}_private.csv") )


### PR DESCRIPTION
fixed calls to log_and_print. Made them just print() calls